### PR TITLE
Move IFFMode5StatusRecord under src

### DIFF
--- a/src/edu/nps/moves/dis7/utilities/data/IFFMode5StatusRecord.java
+++ b/src/edu/nps/moves/dis7/utilities/data/IFFMode5StatusRecord.java
@@ -1,4 +1,4 @@
-package edu.nps.moves.dis7.test;
+package edu.nps.moves.dis7.utilities.data;
 
 import java.io.Serializable;
 import java.util.BitSet;

--- a/test/edu/nps/moves/dis7/test/IFFPduTest.java
+++ b/test/edu/nps/moves/dis7/test/IFFPduTest.java
@@ -16,6 +16,7 @@ import edu.nps.moves.dis7.pdus.LayerHeader;
 import edu.nps.moves.dis7.pdus.Mode5TransponderBasicData;
 import edu.nps.moves.dis7.pdus.Pdu;
 import edu.nps.moves.dis7.pdus.SystemIdentifier;
+import edu.nps.moves.dis7.utilities.data.IFFMode5StatusRecord;
 
 @DisplayName("IFFPduTest")
 public class IFFPduTest extends PduTest{


### PR DESCRIPTION
This pull request moves IFFMode5StatusRecord to a more useful location. Discussion related to this: https://github.com/open-dis/opendis7-source-generator/issues/5 . This proposes that the class is kept in this repo, as it is not really a special case class that would otherwise be auto-generated, but rather a data-utility class for instantiating and parsing the data. Feel free to modify the suggestion, the core issue this attempts to fix is that the IFFMode5StatusRecord shouldn't be located in under test.


